### PR TITLE
Windowのサイズ変更検知方法の変更

### DIFF
--- a/UmaMadoManager.Core/Services/INativeWindowManager.cs
+++ b/UmaMadoManager.Core/Services/INativeWindowManager.cs
@@ -9,5 +9,10 @@ namespace UmaMadoManager.Core.Services
         IntPtr GetWindowHandle(string windowName);
         WindowRect GetWindowRect(IntPtr hWnd);
         void ResizeWindow(IntPtr hWnd, WindowRect rect);
+
+        event EventHandler<bool> OnForeground;
+        event EventHandler OnMinimized;
+        event EventHandler OnMoveOrSizeChanged;
+        event EventHandler OnMessageSent;
     }
 }

--- a/UmaMadoManager.Windows/Native/Win32API.cs
+++ b/UmaMadoManager.Windows/Native/Win32API.cs
@@ -5,13 +5,13 @@ namespace UmaMadoManager.Windows.Native
 {
     public static class Win32API
     {
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", SetLastError = true)]
         public static extern int GetWindowInfo(IntPtr hWnd, ref WINDOWINFO pwi);
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", SetLastError = true)]
         public static extern int SetForegroundWindow(IntPtr hWnd);
 
-        [DllImport("user32.dll")]
+        [DllImport("user32.dll", SetLastError = true)]
         public static extern int MoveWindow(IntPtr hWnd, int X, int Y, int nWidth, int nHeight, int bRepaint);
 
         [StructLayout(LayoutKind.Sequential)]

--- a/UmaMadoManager.Windows/Native/Win32API.cs
+++ b/UmaMadoManager.Windows/Native/Win32API.cs
@@ -14,6 +14,17 @@ namespace UmaMadoManager.Windows.Native
         [DllImport("user32.dll", SetLastError = true)]
         public static extern int MoveWindow(IntPtr hWnd, int X, int Y, int nWidth, int nHeight, int bRepaint);
 
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern IntPtr SetWinEventHook(int eventMin, int eventMax, IntPtr hmodWinEventProc, WinEventProc pfnWinEventProc, int idProcess, int idThread, int dwflags);
+
+        public delegate void WinEventProc(IntPtr hWinEventHook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern int UnhookWinEvent(IntPtr hWinEventHook);
+
         // For debugging
         [DllImport("kernel32.dll")]
         public static extern int AllocConsole();
@@ -41,5 +52,18 @@ namespace UmaMadoManager.Windows.Native
             public int right;
             public int bottom;
         }
+
+        public enum WinEventFlag : uint
+        {
+            WINEVENT_INCONTEXT = 0x0004,
+            WINEVENT_OUTOFCONTEXT = 0x0000,
+            WINEVENT_SKIPOWNPROCESS = 0x0002,
+            WINEVENT_SKIPOWNTHREAD = 0x0001,
+        }
+
+        public const int EVENT_SYSTEM_FOREGROUND = 0x00000003;
+        public const int EVENT_SYSTEM_MOVESIZEEND = 0x0000000b;
+        public const int EVENT_SYSTEM_MINIMIZEEND = 0x00000017;
+        public const int EVENT_OBJECT_LOCATIONCHANGE = 0x0000800b;
     }
 }

--- a/UmaMadoManager.Windows/Native/Win32API.cs
+++ b/UmaMadoManager.Windows/Native/Win32API.cs
@@ -14,6 +14,10 @@ namespace UmaMadoManager.Windows.Native
         [DllImport("user32.dll", SetLastError = true)]
         public static extern int MoveWindow(IntPtr hWnd, int X, int Y, int nWidth, int nHeight, int bRepaint);
 
+        // For debugging
+        [DllImport("kernel32.dll")]
+        public static extern int AllocConsole();
+
         [StructLayout(LayoutKind.Sequential)]
         public struct WINDOWINFO
         {

--- a/UmaMadoManager.Windows/Program.cs
+++ b/UmaMadoManager.Windows/Program.cs
@@ -12,6 +12,7 @@ namespace UmaMadoManager.Windows
         [STAThread]
         static void Main()
         {
+            // Native.Win32API.AllocConsole();
             Application.SetHighDpiMode(HighDpiMode.SystemAware);
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);

--- a/UmaMadoManager.Windows/Services/NativeWindowManager.cs
+++ b/UmaMadoManager.Windows/Services/NativeWindowManager.cs
@@ -11,6 +11,62 @@ namespace UmaMadoManager.Windows.Services
 {
     public class NativeWindowManager : INativeWindowManager
     {
+        // Hookを設定した後のHandle
+        private IntPtr hHook;
+        private Native.Win32API.WinEventProc callback;
+
+        public event EventHandler<bool> OnForeground;
+        public event EventHandler OnMinimized;
+        public event EventHandler OnMoveOrSizeChanged;
+        public event EventHandler OnMessageSent;
+
+        public NativeWindowManager()
+        {
+            callback = WinEventProc;
+            hHook = SetWinEventHook(EVENT_SYSTEM_FOREGROUND, EVENT_OBJECT_LOCATIONCHANGE, IntPtr.Zero, callback, 0, 0, (int)(WinEventFlag.WINEVENT_OUTOFCONTEXT | WinEventFlag.WINEVENT_SKIPOWNPROCESS));
+            var err = Marshal.GetLastWin32Error();
+            if (hHook == IntPtr.Zero)
+            {
+                System.Console.WriteLine("Hook set failed...");
+                System.Console.WriteLine($"error code: {err}");
+            }
+        }
+
+        ~NativeWindowManager()
+        {
+            if (hHook != IntPtr.Zero)
+            {
+                UnhookWinEvent(hHook);
+                hHook = IntPtr.Zero;
+                callback = null;
+            }
+        }
+
+        private void WinEventProc(IntPtr hWinEventHook, uint eventType, IntPtr hWnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime)
+        {
+            GetWindowThreadProcessId(hWnd, out var targetProcessId);
+            var process = Process.GetProcessById((int)targetProcessId);
+            var isTarget = process?.MainWindowTitle == "umamusume";
+            switch (eventType)
+            {
+                case EVENT_SYSTEM_FOREGROUND:
+                    OnForeground?.Invoke(this, isTarget);
+                    break;
+                case EVENT_SYSTEM_MINIMIZEEND:
+                    OnMinimized?.Invoke(this, null);
+                    break;
+                case EVENT_SYSTEM_MOVESIZEEND:
+                case EVENT_OBJECT_LOCATIONCHANGE:
+                    OnMoveOrSizeChanged?.Invoke(this, null);
+                    break;
+                default:
+                    if (isTarget) {
+                        OnMessageSent?.Invoke(this, null);
+                    }
+                    return;
+            }
+        }
+
         public IntPtr GetWindowHandle(string windowName)
         {
             try


### PR DESCRIPTION
今まではPollingで行っていたが、反応が遅れることもあり、ライブ始まりに間に合わないみたいなことも起きていた。
そのためWinEventsを監視し、ユーザまたはシステムが対象Windowに対して操作を行ったことを取得し、それに応じて処理を行うようにする。