### PR TITLE
Mute機能の実装

### DIFF
--- a/UmaMadoManager.Core/Models/ApplicationState.cs
+++ b/UmaMadoManager.Core/Models/ApplicationState.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace UmaMadoManager.Core.Models
+{
+    public enum ApplicationState
+    {
+        Foreground,
+        Background,
+        Minimized
+    }
+}

--- a/UmaMadoManager.Core/Models/MuteCondition.cs
+++ b/UmaMadoManager.Core/Models/MuteCondition.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace UmaMadoManager.Core.Models
+{
+    public enum MuteCondition
+    {
+        Nop,
+        WhenBackground,
+        WhenMinimize
+    }
+}

--- a/UmaMadoManager.Core/Services/IAudioManager.cs
+++ b/UmaMadoManager.Core/Services/IAudioManager.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace UmaMadoManager.Core.Services
+{
+    // FIXME: Windows依存っぽい実装だからいい感じにする
+    public interface IAudioManager
+    {
+        void SetMute(IntPtr hWnd, bool isMute);
+    }
+}

--- a/UmaMadoManager.Core/Services/INativeWindowManager.cs
+++ b/UmaMadoManager.Core/Services/INativeWindowManager.cs
@@ -11,7 +11,7 @@ namespace UmaMadoManager.Core.Services
         void ResizeWindow(IntPtr hWnd, WindowRect rect);
 
         event EventHandler<bool> OnForeground;
-        event EventHandler OnMinimized;
+        event EventHandler<bool> OnMinimized;
         event EventHandler OnMoveOrSizeChanged;
         event EventHandler OnMessageSent;
     }

--- a/UmaMadoManager.Windows/Native/Win32API.cs
+++ b/UmaMadoManager.Windows/Native/Win32API.cs
@@ -63,6 +63,7 @@ namespace UmaMadoManager.Windows.Native
 
         public const int EVENT_SYSTEM_FOREGROUND = 0x00000003;
         public const int EVENT_SYSTEM_MOVESIZEEND = 0x0000000b;
+        public const int EVENT_SYSTEM_MINIMIZESTART = 0x00000016;
         public const int EVENT_SYSTEM_MINIMIZEEND = 0x00000017;
         public const int EVENT_OBJECT_LOCATIONCHANGE = 0x0000800b;
     }

--- a/UmaMadoManager.Windows/Program.cs
+++ b/UmaMadoManager.Windows/Program.cs
@@ -19,8 +19,9 @@ namespace UmaMadoManager.Windows
 
             var nativeWindowManager = new NativeWindowManager();
             var screenManager = new ScreenManager();
+            var audioManager = new AudioManager();
 
-            var _ = new Views.UmaMadoManagerUI(new Core.ViewModels.AxisStandardViewModel(nativeWindowManager, screenManager));
+            var _ = new Views.UmaMadoManagerUI(new Core.ViewModels.AxisStandardViewModel(nativeWindowManager, screenManager, audioManager));
             Application.Run();
         }
     }

--- a/UmaMadoManager.Windows/Services/AudioManager.cs
+++ b/UmaMadoManager.Windows/Services/AudioManager.cs
@@ -1,0 +1,32 @@
+using System;
+using NAudio.CoreAudioApi; //Wasapi
+using UmaMadoManager.Core.Services;
+using static UmaMadoManager.Windows.Native.Win32API;
+
+namespace UmaMadoManager.Windows.Services
+{
+    public class AudioManager : IAudioManager
+    {
+        public void SetMute(IntPtr hWnd, bool isMute)
+        {
+            var deviceEnumerator = new MMDeviceEnumerator();
+            var device = deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+
+            GetWindowThreadProcessId(hWnd, out var processId);
+
+            var sessions = device.AudioSessionManager.Sessions;
+            var sessionCount = sessions.Count;
+
+            for (var i = 0; i < sessionCount; i++)
+            {
+                var session = device.AudioSessionManager.Sessions[i];
+                if (session.GetProcessID != processId)
+                {
+                    continue;
+                }
+
+                session.SimpleAudioVolume.Mute = isMute;
+            }
+        }
+    }
+}

--- a/UmaMadoManager.Windows/Services/NativeWindowManager.cs
+++ b/UmaMadoManager.Windows/Services/NativeWindowManager.cs
@@ -16,7 +16,7 @@ namespace UmaMadoManager.Windows.Services
         private Native.Win32API.WinEventProc callback;
 
         public event EventHandler<bool> OnForeground;
-        public event EventHandler OnMinimized;
+        public event EventHandler<bool> OnMinimized;
         public event EventHandler OnMoveOrSizeChanged;
         public event EventHandler OnMessageSent;
 
@@ -52,15 +52,19 @@ namespace UmaMadoManager.Windows.Services
                 case EVENT_SYSTEM_FOREGROUND:
                     OnForeground?.Invoke(this, isTarget);
                     break;
+                case EVENT_SYSTEM_MINIMIZESTART:
+                    OnMinimized?.Invoke(this, true);
+                    return;
                 case EVENT_SYSTEM_MINIMIZEEND:
-                    OnMinimized?.Invoke(this, null);
+                    OnMinimized?.Invoke(this, false);
                     break;
                 case EVENT_SYSTEM_MOVESIZEEND:
                 case EVENT_OBJECT_LOCATIONCHANGE:
                     OnMoveOrSizeChanged?.Invoke(this, null);
                     break;
                 default:
-                    if (isTarget) {
+                    if (isTarget)
+                    {
                         OnMessageSent?.Invoke(this, null);
                     }
                     return;

--- a/UmaMadoManager.Windows/UmaMadoManager.Windows.csproj
+++ b/UmaMadoManager.Windows/UmaMadoManager.Windows.csproj
@@ -18,7 +18,7 @@
     <EmbeddedResource Include="Resources\TrayIcon.ico" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NAudio" Version="2.0.0" />
+    <PackageReference Include="NAudio.Wasapi" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/UmaMadoManager.Windows/UmaMadoManager.Windows.csproj
+++ b/UmaMadoManager.Windows/UmaMadoManager.Windows.csproj
@@ -17,5 +17,8 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\TrayIcon.ico" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NAudio" Version="2.0.0" />
+  </ItemGroup>
 
 </Project>

--- a/UmaMadoManager.Windows/Views/UmaMadoManagerUI.cs
+++ b/UmaMadoManager.Windows/Views/UmaMadoManagerUI.cs
@@ -98,9 +98,46 @@ namespace UmaMadoManager.Windows.Views
                 }),
             });
 
+            var muteSettingMenus = new ToolStripMenuItem()
+            {
+                Text = "Mute",
+            };
+            muteSettingMenus.DropDownItems.AddRange(new ToolStripItem[]{
+                new ToolStripMenuItem("Nop").Also(v => {
+                    this.Disposable.Add(Observable.FromEventPattern(v, nameof(v.Click)).Subscribe(x => {
+                        _VM.MuteCondition.Value = MuteCondition.Nop;
+                    }));
+                    this.Disposable.Add(_VM.MuteCondition.Subscribe(x => {
+                        v.Checked = x == MuteCondition.Nop;
+                    }));
+                    v.CheckOnClick = true;
+                }),
+                new ToolStripMenuItem("When Background").Also(v => {
+                    this.Disposable.Add(Observable.FromEventPattern(v, nameof(v.Click)).Subscribe(x => {
+                        _VM.MuteCondition.Value = MuteCondition.WhenBackground;
+                    }));
+                    this.Disposable.Add(_VM.MuteCondition.Subscribe(x => {
+                        v.Checked = x == MuteCondition.WhenBackground;
+                    }));
+                    v.CheckOnClick = true;
+                }),
+                new ToolStripMenuItem("When Minimized").Also(v => {
+                    this.Disposable.Add(Observable.FromEventPattern(v, nameof(v.Click)).Subscribe(x => {
+                        _VM.MuteCondition.Value = MuteCondition.WhenMinimize;
+                    }));
+                    this.Disposable.Add(_VM.MuteCondition.Subscribe(x => {
+                        v.Checked = x == MuteCondition.WhenMinimize;
+                    }));
+                    v.CheckOnClick = true;
+                }),
+            });
+
             contextMenu.Items.AddRange(new ToolStripItem[]{
                 verticalSettingMenus,
                 horizontalSettingMenus,
+                new ToolStripSeparator(),
+                muteSettingMenus,
+                new ToolStripSeparator(),
                 new ToolStripMenuItem("Exit").Also(v => {
                     v.Click += (_, _) => {
                         trayNotifyIcon.Icon = null;


### PR DESCRIPTION
## なぜMute機能が必要なのか

近日中に画面サイズと位置を保存する機能を実装予定である。
目的としては攻略サイトを見ながら、仕事をしながら、みたいなながらを行う際に位置が固定されていた方がプレーしやすいだろうという仮定がある。

それとMuteの実装はつながらなくない？という感じではあるが、ながらの中の例えば仕事をしながらみたいな場合、急にミーティングを行うだとかそういう場合に最小化したら音が消えてくれないと…みたいなケースがあり、それに対応したいため実装。

## 仕様

TrayIconを右クリックするとMuteの項目がありその中に3つの選択可能な箇所がある。

### Nop

デフォルトの挙動、何も行わない

### When Background

WindowがForegroundではなくなった場合Muteになる。
また最小化されてもMuteになる。
ForegroundになるとUnMuteを行う。

### When Minimized

最小化が行われたらMuteになる。
Foreground、Foregroundではない場合の両方でUnMuteを行う。