### PR TITLE
対象の画面のサイズ計算がずれていたので直す

### DIFF
--- a/UmaMadoManager.Core/Models/Screen.cs
+++ b/UmaMadoManager.Core/Models/Screen.cs
@@ -11,59 +11,64 @@ namespace UmaMadoManager.Core.Models
         public bool ContainsWindow(WindowRect rect)
         {
             // 含むというよりは左上の頂点がどこにあるかで判定するようにする
-            return WorkingArea.Left <= rect.Left && rect.Left < WorkingArea.Right && WorkingArea.Top <= rect.Top && rect.Top < WorkingArea.Bottom;
+            return Bounds.Left <= rect.Left && rect.Left < Bounds.Right && Bounds.Top <= rect.Top && rect.Top < Bounds.Bottom;
         }
 
-        public WindowRect MaxContainerbleWindowRect(WindowRect baseRect, WindowFittingStandard fittingStandard)
+        public WindowRect MaxContainerbleWindowRect(WindowRect windowRect, WindowRect clientRect, WindowFittingStandard fittingStandard)
         {
-            var workingAreaRatio = (double)WorkingArea.Height / WorkingArea.Width;
-            switch (baseRect.Direction)
+            var marginHeight = (clientRect.Top - windowRect.Top) + (windowRect.Bottom - clientRect.Bottom);
+            var marginWidth = (clientRect.Left - windowRect.Left) + (windowRect.Right - clientRect.Right);
+            var workingAreaRatio = (double)(WorkingArea.Height - marginHeight) / (WorkingArea.Width - marginWidth);
+            switch (windowRect.Direction)
             {
                 case WindowDirection.Horizontal:
-                    if (workingAreaRatio > baseRect.AspectRatio)
+                    if (workingAreaRatio >= windowRect.AspectRatio)
                     {
-                        var baseLength = (double)WorkingArea.Width / baseRect.Width;
+                        var nextClientWidth = WorkingArea.Width - marginWidth;
+                        var nextClientHeight = clientRect.AspectRatio * nextClientWidth;
                         return new WindowRect
                         {
                             Left = WorkingArea.Left,
                             Top = WorkingArea.Top,
                             Right = WorkingArea.Right,
-                            Bottom = (int)Math.Floor(baseRect.Height * baseLength) + WorkingArea.Top,
+                            Bottom = WorkingArea.Top + (int)nextClientHeight + marginHeight,
                         };
                     }
                     else
                     {
-                        var baseLength = (double)WorkingArea.Height / baseRect.Height;
+                        var nextClientHeight = WorkingArea.Bottom - WorkingArea.Top - marginHeight;
+                        var nextClientWidth = nextClientHeight / clientRect.AspectRatio;
                         return new WindowRect
                         {
                             Left = WorkingArea.Left,
                             Top = WorkingArea.Top,
-                            Right = (int)Math.Floor(baseRect.Width * baseLength) + WorkingArea.Left,
+                            Right = WorkingArea.Left + (int)(nextClientWidth) + marginWidth,
                             Bottom = WorkingArea.Bottom,
                         };
                     }
                 case WindowDirection.Vertical:
-                    if (workingAreaRatio < baseRect.AspectRatio)
+                    if (workingAreaRatio < windowRect.AspectRatio)
                     {
-                        var baseLength = (double)WorkingArea.Height / baseRect.Height;
-                        var nextWidth = (int)Math.Floor(baseRect.Width * baseLength);
+                        var nextClientHeight = WorkingArea.Height - marginHeight;
+                        var nextClientWidth = nextClientHeight / clientRect.AspectRatio;
                         return new WindowRect
                         {
-                            Left = fittingStandard == WindowFittingStandard.LeftTop ? WorkingArea.Left : WorkingArea.Right - nextWidth,
+                            Left = fittingStandard == WindowFittingStandard.LeftTop ? WorkingArea.Left : WorkingArea.Right - (int)nextClientWidth - marginWidth,
                             Top = WorkingArea.Top,
-                            Right = fittingStandard == WindowFittingStandard.LeftTop ? WorkingArea.Left + nextWidth : WorkingArea.Right,
+                            Right = fittingStandard == WindowFittingStandard.LeftTop ? WorkingArea.Left + (int)nextClientWidth + marginWidth : WorkingArea.Right,
                             Bottom = WorkingArea.Bottom,
                         };
                     }
                     else
                     {
-                        var baseLength = (double)WorkingArea.Width / baseRect.Width;
+                        var nextClientWidth = WorkingArea.Width - marginWidth;
+                        var nextClientHeight = clientRect.AspectRatio * nextClientWidth;
                         return new WindowRect
                         {
                             Left = WorkingArea.Left,
                             Top = WorkingArea.Top,
                             Right = WorkingArea.Right,
-                            Bottom = (int)Math.Floor(baseRect.Height * baseLength) + WorkingArea.Top,
+                            Bottom = WorkingArea.Top + (int)nextClientHeight + marginHeight,
                         };
                     }
                 default:

--- a/UmaMadoManager.Core/Services/INativeWindowManager.cs
+++ b/UmaMadoManager.Core/Services/INativeWindowManager.cs
@@ -7,7 +7,7 @@ namespace UmaMadoManager.Core.Services
     public interface INativeWindowManager
     {
         IntPtr GetWindowHandle(string windowName);
-        WindowRect GetWindowRect(IntPtr hWnd);
+        (WindowRect window, WindowRect client) GetWindowRect(IntPtr hWnd);
         void ResizeWindow(IntPtr hWnd, WindowRect rect);
         void SetHook(string windowName);
         void SetTopMost(IntPtr hWnd, bool doTop);

--- a/UmaMadoManager.Windows/Services/NativeWindowManager.cs
+++ b/UmaMadoManager.Windows/Services/NativeWindowManager.cs
@@ -51,7 +51,8 @@ namespace UmaMadoManager.Windows.Services
 
         private Native.Win32API.WinEventProc WinEventProc(string windowName)
         {
-            return (IntPtr hWinEventHook, uint eventType, IntPtr hWnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime) => {
+            return (IntPtr hWinEventHook, uint eventType, IntPtr hWnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime) =>
+            {
                 GetWindowThreadProcessId(hWnd, out var targetProcessId);
                 var process = Process.GetProcessById((int)targetProcessId);
                 var isTarget = process?.MainWindowTitle == windowName;
@@ -94,7 +95,7 @@ namespace UmaMadoManager.Windows.Services
             }
         }
 
-        public WindowRect GetWindowRect(IntPtr hWnd)
+        public (WindowRect window, WindowRect client) GetWindowRect(IntPtr hWnd)
         {
             var p = new WINDOWINFO();
             p.cbSize = Marshal.SizeOf<WINDOWINFO>();
@@ -102,16 +103,22 @@ namespace UmaMadoManager.Windows.Services
 
             if (ret == 0)
             {
-                return WindowRect.Empty;
+                return (WindowRect.Empty, WindowRect.Empty);
             }
 
-            return new WindowRect
+            return (new WindowRect
             {
                 Left = p.rcWindow.left,
                 Top = p.rcWindow.top,
                 Bottom = p.rcWindow.bottom,
                 Right = p.rcWindow.right,
-            };
+            }, new WindowRect
+            {
+                Left = p.rcClient.left,
+                Top = p.rcClient.top,
+                Bottom = p.rcClient.bottom,
+                Right = p.rcClient.right,
+            });
         }
 
         public void ResizeWindow(IntPtr hWnd, WindowRect rect)
@@ -121,7 +128,7 @@ namespace UmaMadoManager.Windows.Services
 
         public void SetTopMost(IntPtr hWnd, bool doTop)
         {
-            SetWindowPos(hWnd, (IntPtr)(doTop ? SetWindowPosInsertAfterFlag.HWND_TOPMOST : SetWindowPosInsertAfterFlag.HWND_NOTOPMOST), 0, 0, 0, 0, SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOSIZE); 
+            SetWindowPos(hWnd, (IntPtr)(doTop ? SetWindowPosInsertAfterFlag.HWND_TOPMOST : SetWindowPosInsertAfterFlag.HWND_NOTOPMOST), 0, 0, 0, 0, SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOSIZE);
         }
     }
 }


### PR DESCRIPTION
今まで対象Window全体でサイズの計算をしていたが、そうするとアス比が若干ずれる。
Windowには×ボタンなどの箇所やフレーム、そしてその中身のように入れ子構造になっている。
入れ子の中身のアス比を元に計算しないといけないので、そんな感じにしていく。