### PR TITLE
Border消すモードの実装

### DIFF
--- a/UmaMadoManager.Core/Models/Settings.cs
+++ b/UmaMadoManager.Core/Models/Settings.cs
@@ -87,5 +87,13 @@ namespace UmaMadoManager.Core.Models
             get { return (bool)this["IsMostTop"]; }
             set { this["IsMostTop"] = value; }
         }
+
+        [System.Configuration.UserScopedSettingAttribute()]
+        [System.Configuration.DefaultSettingValue("false")]
+        public bool IsRemoveBorder
+        {
+            get { return (bool)this["IsRemoveBorder"]; }
+            set { this["IsRemoveBorder"] = value; }
+        }
     }
 }

--- a/UmaMadoManager.Core/Services/INativeWindowManager.cs
+++ b/UmaMadoManager.Core/Services/INativeWindowManager.cs
@@ -11,6 +11,7 @@ namespace UmaMadoManager.Core.Services
         void ResizeWindow(IntPtr hWnd, WindowRect rect);
         void SetHook(string windowName);
         void SetTopMost(IntPtr hWnd, bool doTop);
+        void RemoveBorder(IntPtr hWnd, bool doRemove);
 
         event EventHandler<bool> OnForeground;
         event EventHandler<bool> OnMinimized;

--- a/UmaMadoManager.Core/Services/INativeWindowManager.cs
+++ b/UmaMadoManager.Core/Services/INativeWindowManager.cs
@@ -17,5 +17,6 @@ namespace UmaMadoManager.Core.Services
         event EventHandler<bool> OnMinimized;
         event EventHandler OnMoveOrSizeChanged;
         event EventHandler OnMessageSent;
+        event EventHandler OnBorderChanged;
     }
 }

--- a/UmaMadoManager.Core/ViewModels/AxisStandardViewModel.cs
+++ b/UmaMadoManager.Core/ViewModels/AxisStandardViewModel.cs
@@ -79,9 +79,13 @@ namespace UmaMadoManager.Core.ViewModels
 
             Disposable.Add(TargetApplicationName.Subscribe(x => nativeWindowManager.SetHook(x)));
 
+            var observableBorderChanged = Observable.FromEventPattern(nativeWindowManager, nameof(nativeWindowManager.OnBorderChanged)).StartWith(new object[] { null });
+            var observableOnMoveChanged = Observable.FromEventPattern(nativeWindowManager, nameof(nativeWindowManager.OnMoveOrSizeChanged)).Throttle(TimeSpan.FromMilliseconds(200)).StartWith(new object[] { null });
+
             var windowRect = targetWindowHandle
                 .CombineLatest(
-                    Observable.FromEventPattern(nativeWindowManager, nameof(nativeWindowManager.OnMoveOrSizeChanged))
+                    observableOnMoveChanged,
+                    observableBorderChanged.Delay(TimeSpan.FromMilliseconds(500))
                 )
                 .Select(x =>
                 {

--- a/UmaMadoManager.Core/ViewModels/AxisStandardViewModel.cs
+++ b/UmaMadoManager.Core/ViewModels/AxisStandardViewModel.cs
@@ -29,6 +29,8 @@ namespace UmaMadoManager.Core.ViewModels
         public ReactiveProperty<string> LatestVersion { get; }
         public ReactiveProperty<bool> IsMostTop { get; }
 
+        public ReactiveProperty<bool> IsRemoveBorder { get; }
+
         private ReadOnlyReactiveProperty<IntPtr> targetWindowHandle;
 
         private ReactiveProperty<T> BindSettings<T>(T val, string nameofParameter, ReactivePropertyMode mode = ReactivePropertyMode.Default)
@@ -66,6 +68,7 @@ namespace UmaMadoManager.Core.ViewModels
             UserDefinedVerticalWindowRect = BindSettings(settings.UserDefinedVerticalWindowRect, nameof(settings.UserDefinedVerticalWindowRect));
             UserDefinedHorizontalWindowRect = BindSettings(settings.UserDefinedHorizontalWindowRect, nameof(settings.UserDefinedHorizontalWindowRect));
             IsMostTop = BindSettings(settings.IsMostTop, nameof(settings.IsMostTop));
+            IsRemoveBorder = BindSettings(settings.IsRemoveBorder, nameof(settings.IsRemoveBorder));
 
             // FIXME: PollingじゃなくてGlobalHookとかでやりたい
             targetWindowHandle = Observable.Interval(TimeSpan.FromSeconds(1))

--- a/UmaMadoManager.Core/ViewModels/AxisStandardViewModel.cs
+++ b/UmaMadoManager.Core/ViewModels/AxisStandardViewModel.cs
@@ -175,7 +175,7 @@ namespace UmaMadoManager.Core.ViewModels
                 audioManager.SetMute(handle, condition.ToIsMute(state));
             }));
 
-            Disposable.Add(windowRect.DistinctUntilChanged().CombineLatest(targetWindowHandle, Vertical.CombineLatest(WindowFittingStandard, UserDefinedVerticalWindowRect), Horizontal.CombineLatest(UserDefinedHorizontalWindowRect))
+            Disposable.Add(windowRect.DistinctUntilChanged().CombineLatest(targetWindowHandle, Vertical.CombineLatest(WindowFittingStandard, UserDefinedVerticalWindowRect), Horizontal.CombineLatest(UserDefinedHorizontalWindowRect), IsRemoveBorder)
                 .Where(x => x.Second != IntPtr.Zero)
                 .Subscribe(x =>
                 {
@@ -195,9 +195,11 @@ namespace UmaMadoManager.Core.ViewModels
                                 switch (axis)
                                 {
                                     case AxisStandard.Application:
+                                        nativeWindowManager.RemoveBorder(x.Second, false);
                                         return;
                                     case AxisStandard.User:
                                         {
+                                            nativeWindowManager.RemoveBorder(x.Second, false);
                                             if (userDefinedRect.IsEmpty)
                                             {
                                                 return;
@@ -207,7 +209,8 @@ namespace UmaMadoManager.Core.ViewModels
                                         }
                                     case AxisStandard.Full:
                                         {
-                                            var nextSize = containsScreen.Value.MaxContainerbleWindowRect(x.First.Item1, x.First.Item2, Models.WindowFittingStandard.LeftTop /* 使わないので固定値 */);
+                                            var nextSize = containsScreen.Value.MaxContainerbleWindowRect(x.Fifth ? x.First.Item2 : x.First.Item1, x.First.Item2, Models.WindowFittingStandard.LeftTop /* 使わないので固定値 */);
+                                            nativeWindowManager.RemoveBorder(x.Second, x.Fifth);
                                             nativeWindowManager.ResizeWindow(x.Second, nextSize);
                                             return;
                                         }
@@ -221,9 +224,11 @@ namespace UmaMadoManager.Core.ViewModels
                                 switch (axis)
                                 {
                                     case AxisStandard.Application:
+                                        nativeWindowManager.RemoveBorder(x.Second, false);
                                         return;
                                     case AxisStandard.User:
                                         {
+                                            nativeWindowManager.RemoveBorder(x.Second, false);
                                             if (userDefinedRect.IsEmpty)
                                             {
                                                 return;
@@ -233,7 +238,8 @@ namespace UmaMadoManager.Core.ViewModels
                                         }
                                     case AxisStandard.Full:
                                         {
-                                            var nextSize = containsScreen.Value.MaxContainerbleWindowRect(x.First.Item1, x.First.Item2, fittingStandard);
+                                            var nextSize = containsScreen.Value.MaxContainerbleWindowRect(x.Fifth ? x.First.Item2 : x.First.Item1, x.First.Item2, fittingStandard);
+                                            nativeWindowManager.RemoveBorder(x.Second, x.Fifth);
                                             nativeWindowManager.ResizeWindow(x.Second, nextSize);
                                             return;
                                         }

--- a/UmaMadoManager.Windows/Native/Win32API.cs
+++ b/UmaMadoManager.Windows/Native/Win32API.cs
@@ -75,6 +75,7 @@ namespace UmaMadoManager.Windows.Native
         public const int EVENT_SYSTEM_MINIMIZESTART = 0x00000016;
         public const int EVENT_SYSTEM_MINIMIZEEND = 0x00000017;
         public const int EVENT_OBJECT_LOCATIONCHANGE = 0x0000800b;
+        public const int EVENT_OBJECT_REORDER = 0x00008004;
 
         public enum SetWindowPosInsertAfterFlag
         {

--- a/UmaMadoManager.Windows/Native/Win32API.cs
+++ b/UmaMadoManager.Windows/Native/Win32API.cs
@@ -28,6 +28,12 @@ namespace UmaMadoManager.Windows.Native
         [DllImport("user32.dll", SetLastError = true)]
         public static extern int UnhookWinEvent(IntPtr hWinEventHook);
 
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+
         // For debugging
         [DllImport("kernel32.dll")]
         public static extern int AllocConsole();
@@ -95,6 +101,70 @@ namespace UmaMadoManager.Windows.Native
             SWP_NOSIZE = 0x0001,
             SWP_NOZORDER = 0x0004,
             SWP_SHOWWINDOW = 0x0040,
+        }
+
+        [Flags]
+        public enum ExtendWindowStyle : long
+        {
+            WS_EX_ACCEPTFILES = 0x00000010L,
+            WS_EX_APPWINDOW = 0x00040000L,
+            WS_EX_CLIENTEDGE = 0x00000200L,
+            WS_EX_COMPOSITED = 0x02000000L,
+            WS_EX_CONTEXTHELP = 0x00000400L,
+            WS_EX_CONTROLPARENT = 0x00010000L,
+            WS_EX_DLGMODALFRAME = 0x00000001L,
+            WS_EX_LAYERED = 0x00080000,
+            WS_EX_LAYOUTRTL = 0x00400000L,
+            WS_EX_LEFT = 0x00000000L,
+            WS_EX_LEFTSCROLLBAR = 0x00004000L,
+            WS_EX_LTRREADING = 0x00000000L,
+            WS_EX_MDICHILD = 0x00000040L,
+            WS_EX_NOACTIVATE = 0x08000000L,
+            WS_EX_NOINHERITLAYOUT = 0x00100000L,
+            WS_EX_NOPARENTNOTIFY = 0x00000004L,
+            WS_EX_NOREDIRECTIONBITMAP = 0x00200000L,
+            WS_EX_OVERLAPPEDWINDOW = (WS_EX_WINDOWEDGE | WS_EX_CLIENTEDGE),
+            WS_EX_PALETTEWINDOW = (WS_EX_WINDOWEDGE | WS_EX_TOOLWINDOW | WS_EX_TOPMOST),
+            WS_EX_RIGHT = 0x00001000L,
+            WS_EX_RIGHTSCROLLBAR = 0x00000000L,
+            WS_EX_RTLREADING = 0x00002000L,
+            WS_EX_STATICEDGE = 0x00020000L,
+            WS_EX_TOOLWINDOW = 0x00000080L,
+            WS_EX_TOPMOST = 0x00000008L,
+            WS_EX_TRANSPARENT = 0x00000020L,
+            WS_EX_WINDOWEDGE = 0x00000100L
+        }
+
+        [Flags]
+        public enum WindowStyle : long
+        {
+            WS_BORDER = 0x00800000L,
+            WS_CAPTION = 0x00C00000L,
+            WS_CHILD = 0x40000000L,
+            WS_CHILDWINDOW = 0x40000000L,
+            WS_CLIPCHILDREN = 0x02000000L,
+            WS_CLIPSIBLINGS = 0x04000000L,
+            WS_DISABLED = 0x08000000L,
+            WS_DLGFRAME = 0x00400000L,
+            WS_GROUP = 0x00020000L,
+            WS_HSCROLL = 0x00100000L,
+            WS_ICONIC = 0x20000000L,
+            WS_MAXIMIZE = 0x01000000L,
+            WS_MAXIMIZEBOX = 0x00010000L,
+            WS_MINIMIZE = 0x20000000L,
+            WS_MINIMIZEBOX = 0x00020000L,
+            WS_OVERLAPPED = 0x00000000L,
+            WS_OVERLAPPEDWINDOW = (WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX),
+            WS_POPUP = 0x80000000L,
+            WS_POPUPWINDOW = (WS_POPUP | WS_BORDER | WS_SYSMENU),
+            WS_SIZEBOX = 0x00040000L,
+            WS_SYSMENU = 0x00080000L,
+            WS_TABSTOP = 0x00010000L,
+            WS_THICKFRAME = 0x00040000L,
+            WS_TILED = 0x00000000L,
+            WS_TILEDWINDOW = (WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX),
+            WS_VISIBLE = 0x10000000L,
+            WS_VSCROLL = 0x00200000L
         }
     }
 }

--- a/UmaMadoManager.Windows/Services/NativeWindowManager.cs
+++ b/UmaMadoManager.Windows/Services/NativeWindowManager.cs
@@ -19,6 +19,7 @@ namespace UmaMadoManager.Windows.Services
         public event EventHandler<bool> OnMinimized;
         public event EventHandler OnMoveOrSizeChanged;
         public event EventHandler OnMessageSent;
+        public event EventHandler OnBorderChanged;
 
         ~NativeWindowManager()
         {
@@ -73,6 +74,11 @@ namespace UmaMadoManager.Windows.Services
                     case EVENT_OBJECT_LOCATIONCHANGE:
                     if (!isTarget) return;
                         OnMoveOrSizeChanged?.Invoke(this, null);
+                        break;
+                    case EVENT_OBJECT_REORDER:
+                        if (!isTarget) return;
+                        if (idObject != 0 /* WindowObjId*/) return;
+                        OnBorderChanged?.Invoke(this, null);
                         break;
                     default:
                         if (isTarget)

--- a/UmaMadoManager.Windows/Services/NativeWindowManager.cs
+++ b/UmaMadoManager.Windows/Services/NativeWindowManager.cs
@@ -133,5 +133,14 @@ namespace UmaMadoManager.Windows.Services
         {
             SetWindowPos(hWnd, (IntPtr)(doTop ? SetWindowPosInsertAfterFlag.HWND_TOPMOST : SetWindowPosInsertAfterFlag.HWND_NOTOPMOST), 0, 0, 0, 0, SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOSIZE);
         }
+
+        public void RemoveBorder(IntPtr hWnd, bool doRemove)
+        {
+            var currentStyle = (WindowStyle)GetWindowLong(hWnd, -16);
+            var borderStyle = (WindowStyle.WS_CAPTION | WindowStyle.WS_THICKFRAME | WindowStyle.WS_MINIMIZEBOX | WindowStyle.WS_MAXIMIZEBOX | WindowStyle.WS_SYSMENU);
+            var nextStyle = doRemove ? currentStyle & ~borderStyle : currentStyle | borderStyle;
+            SetWindowLong(hWnd, -16, (int)nextStyle);
+            SetWindowPos(hWnd, IntPtr.Zero, 0, 0, 0, 0, SetWindowPosFlags.SWP_FRAMECHANGED | SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOSIZE | SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_NOOWNERZORDER);
+        }
     }
 }

--- a/UmaMadoManager.Windows/Views/UmaMadoManagerUI.cs
+++ b/UmaMadoManager.Windows/Views/UmaMadoManagerUI.cs
@@ -190,6 +190,15 @@ namespace UmaMadoManager.Windows.Views
                         }));
                         vv.CheckOnClick = true;
                     }));
+                    v.DropDownItems.Add(new ToolStripMenuItem("RemoveBorder").Also(vv => {
+                        this.Disposable.Add(Observable.FromEventPattern(vv, nameof(vv.Click)).Subscribe(x => {
+                            _VM.IsRemoveBorder.Value = !_VM.IsRemoveBorder.Value;
+                        }));
+                        this.Disposable.Add(_VM.IsRemoveBorder.Subscribe(x => {
+                            v.Checked = _VM.IsRemoveBorder.Value;
+                        }));
+                        v.CheckOnClick = true;
+                    }));
                 }),
                 new ToolStripSeparator(),
                 new ToolStripMenuItem("Help").Also(v => {


### PR DESCRIPTION
疑似フルスクリーンモードの時にタイトルバーやWindowの8pxのマージンなどを消し去るモードを実装する。
これでより没入感のあるプレーが出来るだろう。

しかし実装があまりよくなく、**Borderを復元した後明示的にWindowサイズをユーザ側で変更しないと**、Borderが消えた時のWindowサイズでClientの領域計算をしてしまい、**クリック位置がずれる**という不具合をこのパッチには入っている。
対処に時間がかかりそうなので、制限付きという扱いでリリースを行う。

また疑似フルスクリーンモード以外では利用できないようになっている。
というのも、アプリケーション側が変更したサイズを使用する場合、Borderなどがないとリサイズも移動も出来なくなるので画面の真ん中に小さいWindowがたたずむ感じになり体験が悪くなる。
ユーザ指定の場合はボーダーを消してもいいかもしれないが、これもまた移動が出来ないし、現在の設計上Windowサイズしか考慮してなくてClientサイズを考慮おらず、ボーダーを消した際の適切なサイズの計算が行えないためである。