### PR TITLE
常にMute状態に出来るような状態を作っておく

### DIFF
--- a/UmaMadoManager.Core/Models/MuteCondition.cs
+++ b/UmaMadoManager.Core/Models/MuteCondition.cs
@@ -5,6 +5,7 @@ namespace UmaMadoManager.Core.Models
     public enum MuteCondition
     {
         Nop,
+        Always,
         WhenBackground,
         WhenMinimize
     }
@@ -16,6 +17,7 @@ namespace UmaMadoManager.Core.Models
             return (self, currentState) switch
             {
                 (MuteCondition.Nop, _) => false,
+                (MuteCondition.Always, _) => true,
                 (_, ApplicationState.Foreground) => false,
                 (MuteCondition.WhenBackground, ApplicationState.Background or ApplicationState.Minimized) => true,
                 (MuteCondition.WhenMinimize, ApplicationState.Minimized) => true,

--- a/UmaMadoManager.Windows/Views/UmaMadoManagerUI.cs
+++ b/UmaMadoManager.Windows/Views/UmaMadoManagerUI.cs
@@ -139,6 +139,15 @@ namespace UmaMadoManager.Windows.Views
                     }));
                     v.CheckOnClick = true;
                 }),
+                new ToolStripMenuItem("Always").Also(v => {
+                    this.Disposable.Add(Observable.FromEventPattern(v, nameof(v.Click)).Subscribe(x => {
+                        _VM.MuteCondition.Value = MuteCondition.Always;
+                    }));
+                    this.Disposable.Add(_VM.MuteCondition.Subscribe(x => {
+                        v.Checked = x == MuteCondition.Always;
+                    }));
+                    v.CheckOnClick = true;
+                }),
                 new ToolStripMenuItem("When Background").Also(v => {
                     this.Disposable.Add(Observable.FromEventPattern(v, nameof(v.Click)).Subscribe(x => {
                         _VM.MuteCondition.Value = MuteCondition.WhenBackground;


### PR DESCRIPTION
デスクトップウィジェット的に放置しているときに誤ってクリックしてしまったときに音声が流れてしまうことがしばしば起きていたので、常にMuteにする機能を付けておく

`Nop`に戻すとUnmuteになるので問題ないだろう