### PR TITLE
重すぎるので高速化する

### DIFF
--- a/UmaMadoManager.Core/Services/INativeWindowManager.cs
+++ b/UmaMadoManager.Core/Services/INativeWindowManager.cs
@@ -10,6 +10,7 @@ namespace UmaMadoManager.Core.Services
         (WindowRect window, WindowRect client) GetWindowRect(IntPtr hWnd);
         void ResizeWindow(IntPtr hWnd, WindowRect rect);
         void SetHook(string windowName);
+        void SetTargetProcessHandler(IntPtr processPtr);
         void SetTopMost(IntPtr hWnd, bool doTop);
         void RemoveBorder(IntPtr hWnd, bool doRemove);
 

--- a/UmaMadoManager.Core/ViewModels/AxisStandardViewModel.cs
+++ b/UmaMadoManager.Core/ViewModels/AxisStandardViewModel.cs
@@ -72,7 +72,7 @@ namespace UmaMadoManager.Core.ViewModels
             IsRemoveBorder = BindSettings(settings.IsRemoveBorder, nameof(settings.IsRemoveBorder));
 
             // FIXME: PollingじゃなくてGlobalHookとかでやりたい
-            targetWindowHandle = Observable.Interval(TimeSpan.FromSeconds(1))
+            targetWindowHandle = Observable.Interval(TimeSpan.FromSeconds(5))
                 .CombineLatest(TargetApplicationName)
                 .Select(x => nativeWindowManager.GetWindowHandle(x.Second))
                 .Distinct()

--- a/UmaMadoManager.Core/ViewModels/AxisStandardViewModel.cs
+++ b/UmaMadoManager.Core/ViewModels/AxisStandardViewModel.cs
@@ -78,7 +78,9 @@ namespace UmaMadoManager.Core.ViewModels
                 .Distinct()
                 .ToReadOnlyReactiveProperty();
 
+            // FIXME: TargetApplicationNameが変わってもThreadが変わって動かなくなるわ…
             Disposable.Add(TargetApplicationName.Subscribe(x => nativeWindowManager.SetHook(x)));
+            Disposable.Add(targetWindowHandle.Subscribe(x => nativeWindowManager.SetTargetProcessHandler(x)));
 
             var observableBorderChanged = Observable.FromEventPattern(nativeWindowManager, nameof(nativeWindowManager.OnBorderChanged)).StartWith(new object[] { null });
             var observableOnMoveChanged = Observable.FromEventPattern(nativeWindowManager, nameof(nativeWindowManager.OnMoveOrSizeChanged)).Throttle(TimeSpan.FromMilliseconds(200)).StartWith(new object[] { null });

--- a/UmaMadoManager.Windows/Services/NativeWindowManager.cs
+++ b/UmaMadoManager.Windows/Services/NativeWindowManager.cs
@@ -13,6 +13,7 @@ namespace UmaMadoManager.Windows.Services
     {
         private SafeEventHookHandle hHook;
         private WinEventProc callback;
+        private int _targetProcessId;
 
         public event EventHandler<bool> OnForeground;
         public event EventHandler<bool> OnMinimized;
@@ -27,6 +28,12 @@ namespace UmaMadoManager.Windows.Services
                 hHook.Close();
                 callback = null;
             }
+        }
+
+        public void SetTargetProcessHandler(IntPtr processPtr)
+        {
+            GetWindowThreadProcessId(processPtr, out var targetProcessId);
+            _targetProcessId = targetProcessId;
         }
 
         public void SetHook(string windowName)
@@ -52,8 +59,7 @@ namespace UmaMadoManager.Windows.Services
             return (IntPtr hWinEventHook, WindowsEventHookType eventType, IntPtr hWnd, int idObject, int idChild, int dwEventThread, uint dwmsEventTime) =>
             {
                 GetWindowThreadProcessId(hWnd, out var targetProcessId);
-                var process = Process.GetProcessById((int)targetProcessId);
-                var isTarget = process?.MainWindowTitle == windowName;
+                var isTarget = targetProcessId == _targetProcessId;
                 switch (eventType)
                 {
                     case WindowsEventHookType.EVENT_SYSTEM_FOREGROUND:


### PR DESCRIPTION
Callbackが大量に呼ばれているので、このあたりを改善すると良さそうとあてを付けてやってみる。

SetWinEventHookの条件を絞れば減らすことはできそうだが、実装を大幅に変える必要が出てきそうなので今回は見送る。
Processクラスのメソッドの呼び出しに時間がかかっているので、Callback内では単純な比較だけで済むようにあらかじめProcessIdを特定しておくことで高速化を行う。