### PR TITLE
最大化ボタンを勝手に追加してしまうようにしていたので削除

### DIFF
--- a/UmaMadoManager.Windows/Services/NativeWindowManager.cs
+++ b/UmaMadoManager.Windows/Services/NativeWindowManager.cs
@@ -142,7 +142,7 @@ namespace UmaMadoManager.Windows.Services
         public void RemoveBorder(IntPtr hWnd, bool doRemove)
         {
             var currentStyle = (SetWindowLongFlags)GetWindowLong(hWnd, WindowLongIndexFlags.GWL_STYLE);
-            var borderStyle = (SetWindowLongFlags.WS_CAPTION | SetWindowLongFlags.WS_THICKFRAME | SetWindowLongFlags.WS_MINIMIZEBOX | SetWindowLongFlags.WS_MAXIMIZEBOX | SetWindowLongFlags.WS_SYSMENU);
+            var borderStyle = (SetWindowLongFlags.WS_CAPTION | SetWindowLongFlags.WS_THICKFRAME | SetWindowLongFlags.WS_MINIMIZEBOX | SetWindowLongFlags.WS_SYSMENU);
             var nextStyle = doRemove ? currentStyle & ~borderStyle : currentStyle | borderStyle;
             SetWindowLong(hWnd, WindowLongIndexFlags.GWL_STYLE, nextStyle);
             SetWindowPos(hWnd, IntPtr.Zero, 0, 0, 0, 0, SetWindowPosFlags.SWP_FRAMECHANGED | SetWindowPosFlags.SWP_NOMOVE | SetWindowPosFlags.SWP_NOSIZE | SetWindowPosFlags.SWP_NOZORDER | SetWindowPosFlags.SWP_NOOWNERZORDER);


### PR DESCRIPTION
Twitterなどでスクショを見ていると最大化ボタンがDisableになっている画像が多く見られた。
もしかしてボーダー消す機能を追加した時に何かやらかしちゃいました？と思ってみてみると

```
BaseStyle: WS_EX_LTRREADING, WS_OVERLAPPED, WS_TILED, WS_EX_LEFT,                    , WS_GROUP, WS_THICKFRAME, WS_SYSMENU, WS_CAPTION, WS_CLIPSIBLINGS, WS_VISIBLE
NextStyle: WS_EX_LTRREADING, WS_OVERLAPPED, WS_TILED, WS_EX_LEFT, WS_EX_CONTROLPARENT, WS_GROUP, WS_THICKFRAME, WS_SYSMENU, WS_CAPTION, WS_CLIPSIBLINGS, WS_VISIBLE
```

`WS_EX_CONTROLPARENT` が勝手に追加されていた。
これは数値的には65535で今回削除する`WS_MAXIMIZEBOX`と一致するのでこれを削除する。